### PR TITLE
Removing Background Image

### DIFF
--- a/bicycleparameters/assets/styles.css
+++ b/bicycleparameters/assets/styles.css
@@ -51,9 +51,8 @@ img {
 #reset-button {
 	margin-top: 5px;
 	margin-left: 25%;
-	width: 10%;
+	width: 100px;
 	font-size: 15px;
-
 }
 
 #table-bin {

--- a/bicycleparameters/assets/styles.css
+++ b/bicycleparameters/assets/styles.css
@@ -1,7 +1,5 @@
 html {
 	background-color: rgb(30, 30, 30);
-	background-size: contain;
-	background-image: url(https://images.pexels.com/photos/686230/pexels-photo-686230.jpeg);
 }
 
 #main-header {


### PR DESCRIPTION
Removes the background image and changed the width for the reset button a little. Previously the width was set to be  10% of the page, but I prefer the text inside of it to always be on one line, so I set the width to 100px instead.