### PR TITLE
Hyperlinks and Documentation

### DIFF
--- a/bicycleparameters/assets/styles.css
+++ b/bicycleparameters/assets/styles.css
@@ -12,10 +12,6 @@ html {
 	font-size: 30px;
 }
 
-u {
-	color: rgb(200, 100, 30);
-}
-
 H2 {
 	text-align: center;
 	font-size: 20px;
@@ -99,4 +95,9 @@ img {
 	width: 250px;
 	margin: 5px;
 	border: 5px ridge rgb(60, 60, 90);
+	color: rgb(211, 211, 211);
+}
+
+a:visited {
+	color: rgb(150, 150, 200);
 }

--- a/bicycleparameters/assets/styles.css
+++ b/bicycleparameters/assets/styles.css
@@ -16,10 +16,6 @@ u {
 	color: rgb(200, 100, 30);
 }
 
-ul {
-	color: rgb(200, 100, 30);
-}
-
 H2 {
 	text-align: center;
 	font-size: 20px;

--- a/bicycleparameters/cycle_app.py
+++ b/bicycleparameters/cycle_app.py
@@ -66,8 +66,8 @@ app = dash.Dash(__name__)
 server = app.server  # needed for heroku
 
 app.layout = html.Div([
-    html.U(html.B(html.H1('Bicycle Dynamics Analysis App',
-                          id='main-header'))),
+    html.B(html.H1('Bicycle Dynamics Analysis App',
+                   id='main-header')),
     html.Div(id='dropdown-bin',
              children=[html.H2('Choose a Parameter Set:'),
                        dcc.Dropdown(id='bike-dropdown',
@@ -319,7 +319,7 @@ def plot_update(value, wheel, frame, general, slider):
     # sets loading notification for the plots
 
 
-@app.callback(Output("plot-load", "children"), [Input("geometry-bin", "children"), Input('eigen-bin','children')])
+@app.callback(Output("plot-load", "children"), [Input("geometry-bin", "children"), Input('eigen-bin', 'children')])
 def input_triggers_spinner(value):
     time.sleep(1)
     return value

--- a/bicycleparameters/cycle_app.py
+++ b/bicycleparameters/cycle_app.py
@@ -64,10 +64,10 @@ GENERAL_LABELS = ['Wheel Base [m]:',
 
 app = dash.Dash(__name__)
 app.title='Bicycle Dynamics Analysis App'
-server = app.server  # needed for heroku
+server=app.server  # needed for heroku
 
 app.layout = html.Div([
-    html.B(html.H1('Bicycle Dynamics Analysis App',
+    html.B(html.H1(app.title,
                    id='main-header')),
     html.Div(id='dropdown-bin',
              children=[html.H2('Choose a Parameter Set:'),

--- a/bicycleparameters/cycle_app.py
+++ b/bicycleparameters/cycle_app.py
@@ -130,15 +130,21 @@ app.layout = html.Div([
                                          'textAlign': 'center', 'backgroundColor': 'rgb(30, 30, 30)'},
                                      editable=True)]),
     html.Div(id='version-bin',
-             children=[html.Ul(children=[html.Li('BicycleParameters v{}'.format(bp.__version__)),
-                                         html.Li('Dash v{}'.format(
-                                             dash.__version__)),
-                                         html.Li('NumPy v{}'.format(
-                                             np.__version__)),
-                                         html.Li('Pandas v{}'.format(
-                                             pd.__version__)),
-                                         html.Li('Matplolib v{}'.format(
-                                             matplotlib.__version__)),
+             children=[html.Ul(children=[html.A(href='https://github.com/moorepants/BicycleParameters',
+                                                target='_blank',
+                                                children=html.Li('BicycleParameters v{}'.format(bp.__version__))),
+                                         html.A(href='https://dash.plotly.com/',
+                                                target='_blank',
+                                                children=html.Li('Dash v{}'.format(dash.__version__))),
+                                         html.A(href='https://numpy.org/devdocs/',
+                                                target='_blank',
+                                                children=html.Li('NumPy v{}'.format(np.__version__))),
+                                         html.A(href='https://pandas.pydata.org/pandas-docs/stable/',
+                                                target='_blank',
+                                                children=html.Li('Pandas v{}'.format(pd.__version__))),
+                                         html.A(href='https://matplotlib.org/contents.html',
+                                                target='_blank',
+                                                children=html.Li('Matplolib v{}'.format(matplotlib.__version__))),
                                          ])]),
 ])
 

--- a/bicycleparameters/cycle_app.py
+++ b/bicycleparameters/cycle_app.py
@@ -63,6 +63,7 @@ GENERAL_LABELS = ['Wheel Base [m]:',
                   'Gravity [N/kg]:']
 
 app = dash.Dash(__name__)
+app.title='Bicycle Dynamics Analysis App'
 server = app.server  # needed for heroku
 
 app.layout = html.Div([

--- a/bicycleparameters/cycle_app.py
+++ b/bicycleparameters/cycle_app.py
@@ -64,7 +64,7 @@ GENERAL_LABELS = ['Wheel Base [m]:',
 
 app = dash.Dash(__name__)
 app.title = 'Bicycle Dynamics Analysis App'
-server=app.server  # needed for heroku
+server = app.server  # needed for heroku
 
 app.layout = html.Div([
     html.B(html.H1(app.title,

--- a/bicycleparameters/cycle_app.py
+++ b/bicycleparameters/cycle_app.py
@@ -63,7 +63,7 @@ GENERAL_LABELS = ['Wheel Base [m]:',
                   'Gravity [N/kg]:']
 
 app = dash.Dash(__name__)
-app.title='Bicycle Dynamics Analysis App'
+app.title = 'Bicycle Dynamics Analysis App'
 server=app.server  # needed for heroku
 
 app.layout = html.Div([


### PR DESCRIPTION
This pull request satisfies all of issue #53. Documentation has been added to each of the dependencies in the bottom left corner, and the github repository has been set as the link attached to the 'Bicycleparemeters v' entry. Additionally, I removed the underline from the title so as not to suggest that it is a link. Finally, I updated `app.title` so that it displays the proper title in the browser tab and when bookmarked.