### PR TITLE
Changing Datatable Highlighting and Text Color

### DIFF
--- a/bicycleparameters/cycle_app.py
+++ b/bicycleparameters/cycle_app.py
@@ -126,6 +126,20 @@ app.layout = html.Div([
                                                          'textAlign': 'center',
                                                          'backgroundColor': 'rgb(30, 30, 30)'
                                                      },
+                                                     style_data_conditional=[
+                                                         {
+                                                             'if': {'state': 'selected'},
+                                                             'backgroundColor': 'rgb(50, 50, 50)', 'color': 'white'
+                                                         },
+                                                         {
+                                                             'if': {'state': 'active'},
+                                                             'backgroundColor': 'rgb(50, 50, 50)', 'color': 'white'
+                                                         },
+                                                         {
+                                                             'if': {'column_editable': False},
+                                                             'cursor': 'not-allowed'
+                                                         },
+                                                     ],
                                                      editable=True),
                                        lg=4),
                                dbc.Col(children=[html.H5('Set the EigenValue Speed Range [m/s]:',
@@ -160,6 +174,20 @@ app.layout = html.Div([
                                                                                     'textAlign': 'center',
                                                                                     'backgroundColor': 'rgb(30, 30, 30)'
                                                                                 },
+                                                                                style_data_conditional=[
+                                                                                    {
+                                                                                        'if': {'state': 'selected'},
+                                                                                        'backgroundColor': 'rgb(50, 50, 50)', 'color': 'white'
+                                                                                    },
+                                                                                    {
+                                                                                        'if': {'state': 'active'},
+                                                                                        'backgroundColor': 'rgb(50, 50, 50)', 'color': 'white'
+                                                                                    },
+                                                                                    {
+                                                                                        'if': {'column_editable': False},
+                                                                                        'cursor': 'not-allowed'
+                                                                                    },
+                                                                                ],
                                                                                 editable=True)),
                                                           dbc.Col(tbl.DataTable(id='general-table',
                                                                                 columns=GENERAL_COLUMNS,
@@ -175,6 +203,20 @@ app.layout = html.Div([
                                                                                     'textAlign': 'center',
                                                                                     'backgroundColor': 'rgb(30, 30, 30)'
                                                                                 },
+                                                                                style_data_conditional=[
+                                                                                    {
+                                                                                        'if': {'state': 'selected'},
+                                                                                        'backgroundColor': 'rgb(50, 50, 50)', 'color': 'white'
+                                                                                    },
+                                                                                    {
+                                                                                        'if': {'state': 'active'},
+                                                                                        'backgroundColor': 'rgb(50, 50, 50)', 'color': 'white'
+                                                                                    },
+                                                                                    {
+                                                                                        'if': {'column_editable': False},
+                                                                                        'cursor': 'not-allowed'
+                                                                                    },
+                                                                                ],
                                                                                 editable=True))
                                                           ])
                                                  ],


### PR DESCRIPTION
The goal here is to change the datatable styling so that when cells are selected, the background color does not change and the text color does not change. Currently on live, the background color becomes a whitish-pink, and the text-color changes to match the unselected grey background color, making the text nearly illegible. My changes here remove the background color changes entirely. The selected cell looks like this; 

![data-color](https://user-images.githubusercontent.com/59950537/86412518-10110300-bc74-11ea-9be6-19365ffc0d6b.PNG)


This pull request will be good to merge once the text color changes are fixed. Alternatively, we can keep the background color changes when selected. However, the font color is still difficult to read except when hovering over a selected cell.