### PR TITLE
Adds a slider to control the Y axis limits on the eigenvalue vs speed plot in the Dash app

### DIFF
--- a/bicycleparameters/cycle_app.py
+++ b/bicycleparameters/cycle_app.py
@@ -169,7 +169,7 @@ app.layout = html.Div([
                                                                   max=100,
                                                                   step=5,
                                                                   value=[
-                                                                      0, 10],
+                                                                      -20, 20],
                                                                  marks={ -100: {'label': '-100', 'style': {'color': '#ffffff'}},
                                                                          -90: {'label': '-90', 'style': {'color': '#ffffff'}},
                                                                          -80: {'label': '-80', 'style': {'color': '#ffffff'}},


### PR DESCRIPTION
This resolved the syntax error and added the y range details to eigen_plot. When I ran the app locally, the new slider showed up and was functioning.