### PR TITLE
Adds a new model that implements full state feedback on the linear Carvallo-Whipple model.

### DIFF
--- a/bicycleparameters/models.py
+++ b/bicycleparameters/models.py
@@ -1092,6 +1092,22 @@ class Meijaard2007WithFeedbackModel(Meijaard2007Model):
         axes : ndarray, shape(2, 4)
             Array of matplotlib axes.
 
+        Examples
+        ========
+
+        .. plot::
+           :include-source: True
+           :context: reset
+
+           import numpy as np
+           from bicycleparameters.parameter_dicts import meijaard2007_browser_jason
+           from bicycleparameters.parameter_sets import Meijaard2007ParameterSet
+           from bicycleparameters.models import Meijaard2007WithFeedbackModel
+           p = Meijaard2007ParameterSet(meijaard2007_browser_jason, True)
+           m = Meijaard2007WithFeedbackModel(p)
+           m.plot_gains(v=np.linspace(0.0, 10.0, num=101),
+                        kTdel_phid=-10.0*np.linspace(0.0, 5.0, num=101))
+
         """
         gain_names = ['kTphi_phi', 'kTphi_del', 'kTphi_phid', 'kTphi_deld',
                       'kTdel_phi', 'kTdel_del', 'kTdel_phid', 'kTdel_deld']

--- a/bicycleparameters/models.py
+++ b/bicycleparameters/models.py
@@ -771,13 +771,10 @@ class Meijaard2007Model(_Model):
 
         if input_func is None:
             def eval_rhs(t, x):
-                x = x.reshape((4, 1))
-                return (A@x).squeeze()
+                return A@x
         else:
             def eval_rhs(t, x):
-                u = input_func(t, x).reshape((2, 1))
-                x = x.reshape((4, 1))
-                return (A@x + B@u).squeeze()
+                return A@x + B@input_func(t, x)
 
         res = spi.solve_ivp(eval_rhs,
                             (times[0], times[-1]),
@@ -840,14 +837,17 @@ class Meijaard2007Model(_Model):
                                     input_func=input_func,
                                     **parameter_overrides)
 
-        fig, axes = plt.subplots(3, sharex=True)
+        fig, axes = plt.subplots(3, sharex=True, layout='constrained')
 
         axes[0].plot(times, inputs)
         axes[0].legend([r'$T_\phi$', r'$T_\delta$'])
+        axes[0].set_ylabel('Torque\n[Nm]')
         axes[1].plot(times, np.rad2deg(res[:, :2]))
         axes[1].legend(['$' + lab + '$' for lab in self.state_vars_latex[:2]])
+        axes[1].set_ylabel('Angle\n[deg]')
         axes[2].plot(times, np.rad2deg(res[:, 2:]))
         axes[2].legend(['$' + lab + '$' for lab in self.state_vars_latex[2:]])
+        axes[2].set_ylabel('Angluar Rate\n[deg/s]')
 
         axes[2].set_xlabel('Time [s]')
 

--- a/bicycleparameters/models.py
+++ b/bicycleparameters/models.py
@@ -969,6 +969,9 @@ class Meijaard2007WithFeedbackModel(Meijaard2007Model):
                                                               |deld |
 
     """
+    def __init__(self, parameter_set):
+        self.parameter_set = parameter_set.to_parameterization(
+            'Meijaard2007WithFeedback')
 
     def form_state_space_matrices(self, **parameter_overrides):
         """Returns the A and B matrices for the Whipple-Carvallo model
@@ -990,20 +993,20 @@ class Meijaard2007WithFeedbackModel(Meijaard2007Model):
 
         where::
 
-           x = |phi     | = |roll angle |
-               |delta   |   |steer angle|
-               |phidot  |   |roll rate  |
-               |deltadot|   |steer rate |
+           x = |phi   | = |roll angle |
+               |delta |   |steer angle|
+               |phid  |   |roll rate  |
+               |deld  |   |steer rate |
 
            K = |0    0      0       0        |
-               |kphi kdelta kphidot kdeltadot|
+               |kTdel_phi kTdel_del kphidot kdeltadot|
 
            u = |Tphi  | = |roll torque |
                |Tdelta|   |steer torque|
 
         """
-        gain_names = ['kphi_phi', 'kphi_del', 'kphi_phid', 'kphi_deld',
-                      'kdel_phi', 'kdel_del', 'kdel_phid', 'kdel_deld']
+        gain_names = ['kTphi_phi', 'kTphi_del', 'kTphi_phid', 'kTphi_deld',
+                      'kTdel_phi', 'kTdel_del', 'kTdel_phid', 'kTdel_deld']
 
         par, arr_keys, arr_len = self._parse_parameter_overrides(
             **parameter_overrides)

--- a/bicycleparameters/models.py
+++ b/bicycleparameters/models.py
@@ -1071,3 +1071,58 @@ class Meijaard2007WithFeedbackModel(Meijaard2007Model):
             A = A - B@K
 
         return A, B
+
+    def plot_gains(self, axes=None, **parameter_overrides):
+        """Plots the gains versus a single varying parameter. The
+        ``parameter_overrides`` should contain one parameter that is an array,
+        other than the eight gains. That parameter will be used for the x axis.
+        The gains can be either arrays of the same length or scalars.
+
+        Parameters
+        ==========
+        axes : array_like, shape(2, 4)
+            Matplotlib axes set to plot to.
+        parameter_overrides : dictionary
+            Parameter keys that map to floats or array_like of floats
+            shape(n,). All keys that map to array_like must be of the same
+            length.
+
+        Returns
+        =======
+        axes : ndarray, shape(2, 4)
+            Array of matplotlib axes.
+
+        """
+        gain_names = ['kTphi_phi', 'kTphi_del', 'kTphi_phid', 'kTphi_deld',
+                      'kTdel_phi', 'kTdel_del', 'kTdel_phid', 'kTdel_deld']
+
+        if axes is None:
+            fig, axes = plt.subplots(2, 4, sharex=True, layout='constrained')
+
+        par, array_keys, array_len = self._parse_parameter_overrides(
+            **parameter_overrides)
+
+        non_gain_array_keys = [k for k in array_keys if k not in gain_names]
+        if len(non_gain_array_keys) == 0:
+            raise ValueError('No x axis key. Set one parameter other than the '
+                             'gains as an array.')
+        else:
+            x_axis_key = non_gain_array_keys[0]
+
+        if len(non_gain_array_keys) > 1:
+            msg = 'More than one array for x axis, choosing {}.'
+            print(msg.format(x_axis_key))
+
+        for ax, name in zip(axes.flatten(), gain_names):
+            if name in array_keys:
+                ax.plot(par[x_axis_key], par[name])
+            else:
+                ax.plot(par[x_axis_key],
+                        par[name]*np.ones_like(par[x_axis_key]))
+            msg = r'${}$'.format(self.parameter_set.par_strings[name])
+            ax.set_title(msg)
+
+        for ax in axes[1, :]:
+            ax.set_xlabel(x_axis_key)
+
+        return axes

--- a/bicycleparameters/parameter_sets.py
+++ b/bicycleparameters/parameter_sets.py
@@ -806,6 +806,120 @@ class Meijaard2007ParameterSet(ParameterSet):
         return ax
 
 
+class Meijaard2007WithFeedbackParameterSet(Meijaard2007ParameterSet):
+    """Represents the parameters of the benchmark bicycle presented in
+    [Meijaard2007]_ and with full state feedback control gains.
+
+    The four bodies are:
+
+    - B: rear frame + rigid rider
+    - F: front wheel
+    - H: front frame (fork & handlebars)
+    - R: rear wheel
+
+    Parameters
+    ==========
+    parameters : dictionary
+        A dictionary mapping variable names to values that contains the
+        following keys:
+
+        - ``IBxx`` : x moment of inertia of the frame/rider [kg*m**2]
+        - ``IBxz`` : xz product of inertia of the frame/rider [kg*m**2]
+        - ``IBzz`` : z moment of inertia of the frame/rider [kg*m**2]
+        - ``IFxx`` : x moment of inertia of the front wheel [kg*m**2]
+        - ``IFyy`` : y moment of inertia of the front wheel [kg*m**2]
+        - ``IHxx`` : x moment of inertia of the handlebar/fork [kg*m**2]
+        - ``IHxz`` : xz product of inertia of the handlebar/fork [kg*m**2]
+        - ``IHzz`` : z moment of inertia of the handlebar/fork [kg*m**2]
+        - ``IRxx`` : x moment of inertia of the rear wheel [kg*m**2]
+        - ``IRyy`` : y moment of inertia of the rear wheel [kg*m**2]
+        - ``c`` : trail [m]
+        - ``g`` : acceleration due to gravity [m/s**2]
+        - ``kTdel_del`` : steer torque feedback gain from steer angle [N*m/rad]
+        - ``kTdel_deld`` : steer torque feedback gain from steer rate [N*m*s/rad]
+        - ``kTdel_phi`` : steer torque feedback gain from roll angle [N*m/rad]
+        - ``kTdel_phid`` : steer torque feedback gain from roll rate [N*m*s/rad]
+        - ``kTphi_del`` : roll torque feedback gain from steer angle [N*m/rad]
+        - ``kTphi_deld`` : roll torque feedback gain from steer rate [N*m*s/rad]
+        - ``kTphi_phi`` : roll torque feedback gain from roll angle [N*m/rad]
+        - ``kTphi_phid`` : roll torque feedback gain from roll rate [N*m*s/rad]
+        - ``lam`` : steer axis tilt [rad]
+        - ``mB`` : frame/rider mass [kg]
+        - ``mF`` : front wheel mass [kg]
+        - ``mH`` : handlebar/fork assembly mass [kg]
+        - ``mR`` : rear wheel mass [kg]
+        - ``rF`` : front wheel radius [m]
+        - ``rR`` : rear wheel radius [m]
+        - ``w`` : wheelbase [m]
+        - ``xB`` : x distance to the frame/rider center of mass [m]
+        - ``xH`` : x distance to the frame/rider center of mass [m]
+        - ``zB`` : z distance to the frame/rider center of mass [m]
+        - ``zH`` : z distance to the frame/rider center of mass [m]
+
+    includes_rider : boolean
+        True if body B is the combined rear frame and rider in terms of
+        mass and inertia values.
+
+    Attributes
+    ==========
+    par_strings : dictionary
+        Maps ASCII strings to their LaTeX string.
+    body_labels : list of strings
+        Single capital letters that correspond to the four rigid bodies in the
+        model.
+
+    References
+    ==========
+
+    .. [Meijaard2007] Meijaard J.P, Papadopoulos Jim M, Ruina Andy and Schwab
+       A.L, 2007, Linearized dynamics equations for the balance and steer of a
+       bicycle: a benchmark and review, Proc. R. Soc. A., 463:1955–1982
+       http://doi.org/10.1098/rspa.2007.1857
+
+    """
+
+    # maps "Python" string to LaTeX version
+    par_strings = {
+        'IBxx': r'I_{Bxx}',
+        'IBxz': r'I_{Bxz}',
+        'IByy': r'I_{Byy}',
+        'IBzz': r'I_{Bzz}',
+        'IFxx': r'I_{Fxx}',
+        'IFyy': r'I_{Fyy}',
+        'IHxx': r'I_{Hxx}',
+        'IHxz': r'I_{Hxz}',
+        'IHyy': r'I_{Hyy}',
+        'IHzz': r'I_{Hzz}',
+        'IRxx': r'I_{Rxx}',
+        'IRyy': r'I_{Ryy}',
+        'c': r'c',
+        'g': r'g',
+        'kTdel_del': r'k_{T_{\delta}\delta}',
+        'kTdel_deld': r'k_{T_{\delta}\dot{\delta}}',
+        'kTdel_phi': r'k_{T_{\delta}\phi}',
+        'kTdel_phid': r'k_{T_{\delta}\dot{\phi}}',
+        'kTphi_del': r'k_{T_{\phi}\delta}',
+        'kTphi_deld': r'k_{T_{\phi}\dot{\delta}}',
+        'kTphi_phi': r'k_{T_{\phi}\phi}',
+        'kTphi_phid': r'k_{T_{\phi}\dot{\phi}}',
+        'lam': r'\lambda',
+        'mB': r'm_B',
+        'mF': r'm_F',
+        'mH': r'm_H',
+        'mR': r'm_R',
+        'rF': r'r_F',
+        'rR': r'r_R',
+        'v': r'v',
+        'w': r'w',
+        'xB': r'x_B',
+        'xH': r'x_H',
+        'zB': r'z_B',
+        'zH': r'z_H',
+    }
+
+    body_labels = ['B', 'F', 'H', 'R']
+
+
 class Moore2019ParameterSet(ParameterSet):
     """Represents the parameters of the bicycle parameterization presented in
     [1]_.

--- a/bicycleparameters/parameter_sets.py
+++ b/bicycleparameters/parameter_sets.py
@@ -301,6 +301,40 @@ class Meijaard2007ParameterSet(ParameterSet):
         self.includes_rider = includes_rider
         self._generate_body_colors()
 
+    def to_parameterization(self, name):
+        """Returns a specific parameter set based on the provided
+        parameterization name.
+
+        Parameters
+        ==========
+        name : string
+            The name of the parameterization. These should correspond to a
+            subclass of a ``ParameterSet`` and the name will be the string that
+            precedes "ParameterSet". For example, the parameterization name of
+            ``Meijaard2007ParameterSet`` is ``Meijaard2007``.
+
+        Returns
+        =======
+        ParmeterSet
+            If a different parameterization is requested and this class can
+            convert itself, it will return a new parameter set of the correct
+            parameterization.
+
+        """
+        if name == self.parameterization:
+            return self
+        elif name == 'Meijaard2007WithFeedback':
+            par = self.parameters.copy()
+            gain_names = ['kTphi_phi', 'kTphi_del', 'kTphi_phid', 'kTphi_deld',
+                          'kTdel_phi', 'kTdel_del', 'kTdel_phid', 'kTdel_deld']
+            for gain in gain_names:
+                par[gain] = 0.0
+            return Meijaard2007WithFeedbackParameterSet(par,
+                                                        self.includes_rider)
+        else:
+            msg = '{} is not an avaialble parameter set'
+            raise ValueError(msg.format(name))
+
     @classmethod
     def _from_yaml(cls, path_to_file):
 
@@ -919,6 +953,9 @@ class Meijaard2007WithFeedbackParameterSet(Meijaard2007ParameterSet):
 
     body_labels = ['B', 'F', 'H', 'R']
 
+    def __init__(self, parameters, includes_rider):
+        super().__init__(parameters, includes_rider)
+
 
 class Moore2019ParameterSet(ParameterSet):
     """Represents the parameters of the bicycle parameterization presented in
@@ -1075,8 +1112,13 @@ class Moore2019ParameterSet(ParameterSet):
             b = _convert_principal_to_benchmark(self.parameters)
             # Moore2019 always includes the rider
             return Meijaard2007ParameterSet(b, True)
+        elif name == 'Meijaard2007WithFeedback':
+            b = _convert_principal_to_benchmark(self.parameters)
+            # Moore2019 always includes the rider
+            par_set = Meijaard2007ParameterSet(b, True)
+            return par_set.to_parameterization(name)
         else:
-            msg = '{} is not an avaialble parameter set'
+            msg = '{} is not an available parameter set'
             raise ValueError(msg.format(name))
 
     def plot_geometry(self, show_steer_axis=True, ax=None):

--- a/bicycleparameters/tests/test_models.py
+++ b/bicycleparameters/tests/test_models.py
@@ -1,8 +1,9 @@
 import numpy as np
 from pytest import raises
 
-from ..parameter_sets import Meijaard2007ParameterSet
-from ..models import Meijaard2007Model
+from ..parameter_sets import (Meijaard2007ParameterSet,
+                              Meijaard2007WithFeedbackParameterSet)
+from ..models import Meijaard2007Model, Meijaard2007WithFeedbackModel
 
 meijaard2007_parameters = {  # dictionary of the parameters in Meijaard 2007
     'IBxx': 9.2,
@@ -141,6 +142,52 @@ def test_Meijaard2007Model(show=False):
     assert evecs.shape == (10, 4, 4)
     model.plot_eigenvalue_parts(v=np.linspace(0, 10, num=10))
     model.plot_eigenvectors(v=np.linspace(0, 10, num=4))
+    if show:
+        import matplotlib.pyplot as plt
+        plt.show()
+
+
+def test_Meijaard2007WithFeedbackModel(show=False):
+
+    parameter_set = Meijaard2007ParameterSet(meijaard2007_parameters, True)
+
+    model = Meijaard2007WithFeedbackModel(parameter_set)
+    assert type(model.parameter_set) == Meijaard2007WithFeedbackParameterSet
+
+    M, C1, K0, K2 = model.form_reduced_canonical_matrices()
+    assert M.shape == (2, 2)
+    assert C1.shape == (2, 2)
+    assert K0.shape == (2, 2)
+    assert K2.shape == (2, 2)
+
+    A, B = model.form_state_space_matrices()
+    assert A.shape == (4, 4)
+    assert B.shape == (4, 2)
+    A, B = model.form_state_space_matrices(w=np.linspace(0.5, 1.5, num=5))
+    assert A.shape == (5, 4, 4)
+    assert B.shape == (5, 4, 2)
+    A, B = model.form_state_space_matrices(v=np.linspace(0, 10, num=10))
+    assert A.shape == (10, 4, 4)
+    assert B.shape == (10, 4, 2)
+
+    A, B = model.form_state_space_matrices(v=np.linspace(0, 10, num=10),
+                                           g=np.linspace(0, 10, num=10))
+    assert A.shape == (10, 4, 4)
+    assert B.shape == (10, 4, 2)
+
+    with raises(ValueError):
+        # one parameter must be an array
+        model.plot_gains()
+
+    model.plot_gains(g=np.linspace(0, 10, num=10))
+
+    model.plot_gains(g=np.linspace(0, 10, num=10),
+                     kTdel_phi=np.linspace(0, 10, num=10))
+
+    model.plot_gains(g=np.linspace(0, 10, num=10),
+                     v=np.linspace(0, 10, num=10),
+                     kTdel_phi=np.linspace(0, 10, num=10))
+
     if show:
         import matplotlib.pyplot as plt
         plt.show()

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -720,7 +720,6 @@ derivative controller on roll:
                                     kdel_phid=Ks[:, 1, 2],
                                     kdel_deld=Ks[:, 1, 3],
                                     colors=['C0', 'C0', 'C1', 'C2'],
-                                    show_stable_regions=False,
                                     hide_zeros=True)
    ax.set_ylim((-10.0, 10.0))
 
@@ -739,5 +738,8 @@ derivative controller on roll:
                          kdel_phi=Ks[90, 1, 0],
                          kdel_del=Ks[90, 1, 1],
                          kdel_phid=Ks[90, 1, 2],
-                         kdel_deld=Ks[90, 1, 3])
+                         kdel_deld=Ks[90, 1, 3],
+                         input_func=lambda t, x: np.array([100.0, 0.0])
+                                                 if (t > 2.5 and t < 2.6)
+                                                 else np.zeros(2))
    ax[0].set_title('$v$ = {} m/s'.format(speeds[90]))

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -796,7 +796,7 @@ so we will only apply control at speeds greater than 0.8 m/s.
    for i, (row, name_row) in enumerate(zip(axes, gain_names)):
        for j, (col, name) in enumerate(zip(row, name_row)):
            col.plot(speeds, Ks[:, i, j])
-           col.set_ylabel(r'${}$'.format(par_set.par_strings[name]))
+           col.set_title(r'${}$'.format(par_set.par_strings[name]))
    for ax in row:
        ax.set_xlabel('v [m/s]')
 
@@ -814,9 +814,7 @@ Now use the computed gains to check for closed loop stability:
                                     kTdel_phi=Ks[:, 1, 0],
                                     kTdel_del=Ks[:, 1, 1],
                                     kTdel_phid=Ks[:, 1, 2],
-                                    kTdel_deld=Ks[:, 1, 3],
-                                    colors=['C0', 'C0', 'C1', 'C2'],
-                                    hide_zeros=True)
+                                    kTdel_deld=Ks[:, 1, 3])
    ax.set_ylim((-10.0, 10.0))
 
 This is stable over a wide speed range and retains the weave eigenfrequency of
@@ -829,7 +827,6 @@ the uncontrolled system.
    x0 = np.deg2rad([5.0, -3.0, 0.0, 0.0])
 
    def input_func(t, x):
-       print('in here')
        if (t > 2.5 and t < 2.6):
            return np.array([200.0, 0.0])
        else:
@@ -850,4 +847,4 @@ the uncontrolled system.
        kTdel_phid=Ks[idx, 1, 2],
        kTdel_deld=Ks[idx, 1, 3],
    )
-   ax[0].set_title('$v$ = {} m/s'.format(speeds[90]))
+   ax[0].set_title('$v$ = {} m/s'.format(speeds[idx]))

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -764,7 +764,7 @@ negative feedback of roll angle to roll torque with damping.
    :include-source: True
    :context: close-figs
 
-   times = np.linspace(0.0, 10.0, num=1001)
+   times = np.linspace(0.0, 5.0, num=1001)
 
    model.plot_mode_simulations(times, v=2.0, kTphi_phi=3000.0,
                                kTphi_phid=600.0)

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -711,7 +711,37 @@ system.
 
    par_set = Meijaard2007WithFeedbackParameterSet(par, True)
 
-   speeds = np.linspace(1.0, 10.0, num=1001)
+It is well known that a simple proportional positive feedback of roll angular
+rate can stablize a bicycle at lower speeds.
+
+.. plot::
+   :include-source: True
+   :context: close-figs
+
+   from bicycleparameters.models import Meijaard2007WithFeedbackModel
+
+   model = Meijaard2007WithFeedbackModel(par_set)
+
+   ax = model.plot_eigenvalue_parts(v=speeds,
+                                    colors=['C0', 'C0', 'C1', 'C2'],
+                                    hide_zeros=True)
+   ax.set_ylim((-10.0, 10.0))
+
+.. plot::
+   :include-source: True
+   :context: close-figs
+
+   ax = model.plot_eigenvalue_parts(v=speeds,
+                                    kTdel_phid=-50.0,
+                                    colors=['C0', 'C0', 'C1', 'C2'],
+                                    hide_zeros=True)
+   ax.set_ylim((-10.0, 10.0))
+
+.. plot::
+   :include-source: True
+   :context: close-figs
+
+   speeds = np.linspace(0.0, 10.0, num=1001)
 
    As, Bs = model.form_state_space_matrices(v=speeds)
    Ks = np.zeros((len(speeds), 2, 4))
@@ -720,8 +750,9 @@ system.
    R = np.eye(1)
 
    for i, (Ai, Bi) in enumerate(zip(As, Bs)):
-       S = solve_continuous_are(Ai, Bi[:, 1:2], Q, R)  # steer torque control
-       Ks[i, 1, :] = (np.linalg.inv(R) @ Bi[:, 1:2].T @  S).squeeze()
+       if i > 100:
+          S = solve_continuous_are(Ai, Bi[:, 1:2], Q, R)  # steer torque control
+          Ks[i, 1, :] = (np.linalg.inv(R) @ Bi[:, 1:2].T @  S).squeeze()
 
    fig, axes = plt.subplots(2, 4, sharex=True, layout='constrained')
    for i, (row, name_row) in enumerate(zip(axes, gain_names)):

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -747,7 +747,7 @@ The stable speed range is significantly increased, but the weave mode
 eigenfrequency is increased as a consequence.
 
 This can also be used to model adding springy training wheels by including a
-negative feedback of roll angle to roll torque.
+negative feedback of roll angle to roll torque with damping.
 
 .. plot::
    :include-source: True
@@ -755,7 +755,7 @@ negative feedback of roll angle to roll torque.
 
    ax = model.plot_eigenvalue_parts(v=speeds,
                                     kTphi_phi=3000.0,
-                                    kTphi_phid=30.0,
+                                    kTphi_phid=600.0,
                                     colors=['C0', 'C0', 'C1', 'C2'],
                                     hide_zeros=True)
    ax.set_ylim((-10.0, 10.0))
@@ -764,9 +764,10 @@ negative feedback of roll angle to roll torque.
    :include-source: True
    :context: close-figs
 
-   times = np.linspace(0.0, 1.0, num=1001)
+   times = np.linspace(0.0, 10.0, num=1001)
 
-   model.plot_mode_simulations(times, v=0.1)
+   model.plot_mode_simulations(times, v=2.0, kTphi_phi=3000.0,
+                               kTphi_phid=600.0)
 
 A more general method to control the bicycle is to create gain scheduling with
 respect to speed using LQR optimal control. Assuming we only control steer

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -122,7 +122,7 @@ looks to see if there are any parameter sets in
 ``./bicycles/Stratos/Parameters/``. If so, it loads the data, if not it looks
 for ``./bicycles/Stratos/RawData/StratosMeasurments.txt`` so that it can
 generate the parameter set. The raw measurement file may or may not contain the
-oscillation period data for the bicycle moment of inertia caluclations. If it
+oscillation period data for the bicycle moment of inertia calculations. If it
 doesn't then the program will look for the series of ``.mat`` files need to
 calculate the periods. If no data is there, then you get an error.
 
@@ -133,9 +133,9 @@ There are other loading options::
 The ``pathToData`` option allows you specify a directory other than the current
 directory as your data directory. The ``forceRawCalc`` forces the program to
 load ``./bicycles/Stratos/RawData/StratosMeasurments.txt`` and recalculate the
-parameters regarless if there are any parameter files available in
+parameters regardless if there are any parameter files available in
 ``./bicycles/Stratos/Parameters/``. The ``forcePeriodCalc`` option forces the period
-calcluation from the ``.mat`` files regardless if they already exist in the raw
+calculation from the ``.mat`` files regardless if they already exist in the raw
 measurement file.
 
 Exploring bicycle parameter data
@@ -490,7 +490,7 @@ displays a simplified depiction::
 
 .. image:: bicycleRiderGeometry.png
 
-The eigenvalue plot also relfects the changes::
+The eigenvalue plot also reflects the changes::
 
   >>> bicycle.plot_eigenvalues_vs_speed(speeds, show=True)
 


### PR DESCRIPTION
If the steer and roll torque are used to stabilize to the upright equilibrium you can use full state feedback to drive all states to zero. This is a general model that implements this feedback and steering/roll torques can still be applied in parallel from the rider. I demonstrate finding a simple LQR controller for all speeds in the docs:
![image](https://github.com/user-attachments/assets/33cac0b0-b2d8-4b01-a9e6-feaf31c36355)

TODO:

- [x] Make a new parameter set that includes these control gains (instead of just adding them in the model.
- [x] Make sure that all the controls are calculated correctly, try some simpler controllers on steer and roll.
- [x] Add unit tests.